### PR TITLE
Fix misstyping in functions.py

### DIFF
--- a/pethublocal/functions.py
+++ b/pethublocal/functions.py
@@ -931,7 +931,7 @@ def ha_update_state(pethubconfig, *devicepet):
                         })
                     elif attrs.Bowl_Count == 1:  # One bowl
                         state_message.update({
-                            'Target': str(device.Bowl_Target[0]),
+                            'Target': str(attrs.Bowl_Target[0]),
                             'Weight': str(attrs.Bowl_Weight[0])
                         })
                     mqtt_messages.merge_update({PH_HA_T + devid + '/state': state_message.to_json()})


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/pethublocal/frontend.py", line 243, in mqtt_start
    ha_init_state = ha_update_state(app['pethubconfig'])
  File "/usr/lib/python3.10/site-packages/pethublocal/functions.py", line 934, in ha_update_state
    'Target': str(device.Bowl_Target[0]),
AttributeError: 'str' object has no attribute 'Bowl_Target'
```