### PR TITLE
Add Github Action to store package

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -1,0 +1,39 @@
+name: Build
+
+on:
+  push:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+    build:
+        name: Build & Deploy
+        runs-on: ubuntu-latest
+
+        steps:
+        - uses: actions/checkout@v2
+
+        - name: Log in to the Container registry
+          uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+          with:
+            registry: ${{ env.REGISTRY }}
+            username: ${{ secrets.GH_USERNAME }}
+            password: ${{ secrets.GH_PAT }}
+
+        - name: Extract metadata (tags, labels) for Docker
+          id: meta
+          uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+          with:
+            images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+        - name: Build and push Docker image
+          uses: docker/build-push-action@v2
+          with:
+            context: .
+            push: ${{ github.actor != 'dependabot[bot]' }}
+            tags: ${{ steps.meta.outputs.tags }}
+            build-args: | 
+              GITHUB_USERNAME=${{ github.actor }}
+              GITHUB_TOKEN=${{ secrets.GH_PAT }}

--- a/workflows/all.yml
+++ b/workflows/all.yml
@@ -1,0 +1,39 @@
+name: Build
+
+on:
+  push:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+    build:
+        name: Build & Deploy
+        runs-on: ubuntu-latest
+
+        steps:
+        - uses: actions/checkout@v2
+
+        - name: Log in to the Container registry
+          uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+          with:
+            registry: ${{ env.REGISTRY }}
+            username: ${{ secrets.GH_USERNAME }}
+            password: ${{ secrets.GH_PAT }}
+
+        - name: Extract metadata (tags, labels) for Docker
+          id: meta
+          uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+          with:
+            images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+        - name: Build and push Docker image
+          uses: docker/build-push-action@v2
+          with:
+            context: .
+            push: ${{ github.actor != 'dependabot[bot]' }}
+            tags: ${{ steps.meta.outputs.tags }}
+            build-args: | 
+              GITHUB_USERNAME=${{ github.actor }}
+              GITHUB_TOKEN=${{ secrets.GH_PAT }}


### PR DESCRIPTION
Hey,

This PR will run a Github Actions workflow on every push and generate a package which is uploaded to github packages

You'll need to add the following repo secrets for it to work:
GH_USERNAME - username of a user to run under
GH_PAT - a Private access token of that user
Just needed to upload the package
