### PR TITLE
Watchdog for Hub "Message of death"

### DIFF
--- a/pethublocal/functions.py
+++ b/pethublocal/functions.py
@@ -30,6 +30,7 @@ from .enums import *
 # Disable annoying urllib HTTPS Warnings
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
+LastMessageFromHub = datetime.utcnow()
 
 def external_dns_query(host, internal=False):
     """
@@ -990,6 +991,7 @@ def parse_mqtt_message(pethubconfig, mqtt_topic, mqtt_message):
             message_split = mqtt_message.split()
             if message_split[1] != "1000":  # Don't process command messages that we have generated
                 log.info('HUB: Inbound Message Topic: "%s" Message: "%s"', mqtt_topic, mqtt_message)
+                update_watchdog();		# Update watchdog timestamp
                 mqtt_messages = parse_hub(pethubconfig, mqtt_topic, mqtt_message)
                 if 'message' in mqtt_messages:
                     for mqttmessage in mqtt_messages.message:
@@ -1268,3 +1270,18 @@ def build_firmware(xor_key, serial_number):
         log.info('Firmware: Custom firmware built')
     else:
         log.info('Firmware %s already exists', firmwares)
+
+
+
+
+def update_watchdog():
+    global LastMessageFromHub
+    LastMessageFromHub = datetime.utcnow()    # Init Watchdog timestamp
+    log.debug('Watchdog timer resetted')
+
+def get_watchdog():
+    global LastMessageFromHub
+    TimeDifference = datetime.utcnow() - LastMessageFromHub
+    SecDifference = TimeDifference.total_seconds()
+    return TimeDifference.seconds
+

--- a/pethublocal/functions.py
+++ b/pethublocal/functions.py
@@ -1277,11 +1277,10 @@ def build_firmware(xor_key, serial_number):
 def update_watchdog():
     global LastMessageFromHub
     LastMessageFromHub = datetime.utcnow()    # Init Watchdog timestamp
-    log.debug('Watchdog timer resetted')
+    log.debug('Watchdog timer was reset')
 
 def get_watchdog():
     global LastMessageFromHub
     TimeDifference = datetime.utcnow() - LastMessageFromHub
-    SecDifference = TimeDifference.total_seconds()
     return TimeDifference.seconds
 


### PR DESCRIPTION
This commit adds a watchdog to solve issue https://github.com/PetHubLocal/pethublocal/issues/11 by implementing my idea https://github.com/PetHubLocal/pethublocal/issues/17.

Even without pet action or flap status messages, the hub sends a status telegram at least every hour.

The watchdog checks every minute the time since the last message from the hub. If PHL did not see a message for at least 70 minutes, it assumes that the hub is trapped in its "loop of death" described in https://github.com/PetHubLocal/pethublocal/issues/11 and it'll stop Mosquitto, delete the persistent data file and restart Mosquitto. This usually solves the loop of death and the Hub will reconnect.

If the Hub is disconnected from the network or powered down, the Watchdog will also do the Mosquitto action every 70 minutes, but this won't harm anything.

Although the watchdog check runs every minute, a status is written into the log file as DEBUG message every 5 minutes to not flood the logfile.
When the watchdog triggers the action, an INFO message is written into the log file.

To function properly, these prerequsites must be fulfilled:
- The local Mosquitto for PHL must run via SYSTEMCTL
- The persistent Mosquitto data must reside in /var/lib/mosquitto/mosquitto.db (the standard location)
- Musquitto on the PHL server *must not be used for anything else but PHL* with an upstream connection to the main Moquitto broker. Otherwise, when the Watchdog triggers persistent data for other applications would also be deleted

If Mosquitto does not run via SYSTEMCTL or if the persistend data location is different, the command in frontend.py, line 315 must be modofied.