### PR TITLE
Various "improvements"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/pethublocal/enums.py
+++ b/pethublocal/enums.py
@@ -302,22 +302,22 @@ class FeederCustomMode(SureFlag):
 class PetDoorCustomMode(SureFlag):
     """ Custom Modes on the Pet Door """
     Disabled = 0              # All custom modes disabled
-    Nonselective = 0x1        # Custom Mode 1 - Non-selective Entry - Unlocks the door inbound so any animal can come in
+    NonSelective = 0x1        # Custom Mode 1 - Non-selective Entry - Unlocks the door inbound so any animal can come in
     Rechargeables = 0x2       # Custom Mode 2 - Rechargeable Batteries so work with lower voltage from 1.2v Rechargeables vs 1.5v Alkaline
-    Threeseconds = 0x4        # Custom Mode 3 - Timid Pets - 3 Seconds delay before closing door
-    Tenseconds = 0x8          # Custom Mode 4 - Slower Locking - 10 Seconds delay before closing door
+    ThreeSeconds = 0x4        # Custom Mode 3 - Timid Pets - 3 Seconds delay before closing door
+    TenSeconds = 0x8          # Custom Mode 4 - Slower Locking - 10 Seconds delay before closing door
     Intruder = 0x10           # Custom Mode 5 - Intruder Mode - Lock outside locks when non-provisioned animal detected by sensor to prevent door being pulled open
-    Oppositecurfew = 0x20     # Custom Mode 6 - Opposite Curfew mode - Lock KeepOut rather than KeepIn
-    Lockedcurfew = 0x40       # Custom Mode 7 - Fully Locking Curfew Mode - Locks both in and out locks when in curfew mode
-    Metalmode1 = 0x80         # Custom Mode 8 - Metal Interference - This mode will help with severe metal interference in an installation
-    Metalmode2 = 0x100        # Custom Mode 9 - Metal Interference - This mode will help with severe metal interference in an installation
-    Extendedrange = 0x200     # Custom Mode 10 - Extended Mode - Extend frequency of scanning the tags
-    Extendedintruder = 0x400  # Custom Mode 11 - Extended Intruder Mode - Extended Intruder Mode - Registers presence of intruder animal trying to enter the house and closes outside lock to prevent door being pulled open for longer period
+    OppositeCurfew = 0x20     # Custom Mode 6 - Opposite Curfew mode - Lock KeepOut rather than KeepIn
+    LockedCurfew = 0x40       # Custom Mode 7 - Fully Locking Curfew Mode - Locks both in and out locks when in curfew mode
+    MetalMode1 = 0x80         # Custom Mode 8 - Metal Interference - This mode will help with severe metal interference in an installation
+    MetalMode2 = 0x100        # Custom Mode 9 - Metal Interference - This mode will help with severe metal interference in an installation
+    ExtendedRange = 0x200     # Custom Mode 10 - Extended Mode - Extend frequency of scanning the tags
+    ExtendedIntruder = 0x400  # Custom Mode 11 - Extended Intruder Mode - Extended Intruder Mode - Registers presence of intruder animal trying to enter the house and closes outside lock to prevent door being pulled open for longer period
     BIT12 = 0x800             # Bit12 - ?
-    Doublechip1 = 0x1000      # Custom Mode 13 - Double Chip Operating Mode 1 - Allow animal with two tags interfering with each other to enter
-    Doublechip2 = 0x2000      # Custom Mode 14 - Double Chip Operating Mode 2 - Allow animal with two tags interfering with each other to enter
-    Doublechip3 = 0x4000      # Custom Mode 15 - Double Chip Operating Mode 3 - Allow animal with two tags interfering with each other to enter
-    Proximitytest = 0x8000    # Custom Mode 16 - Proximity Sensor Test - Test the proximity function of the door.
+    DoubleChip1 = 0x1000      # Custom Mode 13 - Double Chip Operating Mode 1 - Allow animal with two tags interfering with each other to enter
+    DoubleChip2 = 0x2000      # Custom Mode 14 - Double Chip Operating Mode 2 - Allow animal with two tags interfering with each other to enter
+    DoubleChip3 = 0x4000      # Custom Mode 15 - Double Chip Operating Mode 3 - Allow animal with two tags interfering with each other to enter
+    ProximityTest = 0x8000    # Custom Mode 16 - Proximity Sensor Test - Test the proximity function of the door.
 
 
     """

--- a/pethublocal/enums.py
+++ b/pethublocal/enums.py
@@ -301,7 +301,6 @@ class FeederCustomMode(SureFlag):
 
 class PetDoorCustomMode(SureFlag):
     """ Custom Modes on the Pet Door """
-    Disabled = 0              # All custom modes disabled
     NonSelective = 0x1        # Custom Mode 1 - Non-selective Entry - Unlocks the door inbound so any animal can come in
     Rechargeables = 0x2       # Custom Mode 2 - Rechargeable Batteries so work with lower voltage from 1.2v Rechargeables vs 1.5v Alkaline
     ThreeSeconds = 0x4        # Custom Mode 3 - Timid Pets - 3 Seconds delay before closing door

--- a/pethublocal/frontend.py
+++ b/pethublocal/frontend.py
@@ -320,6 +320,7 @@ async def hub_watchdog(app):
         update_watchdog()		# Reload Watchdog timer with current time
       await asyncio.sleep(check_interval)
 
+
 # Monitor the LookedIn state of pets
 # If a pet is in the LookedIn state for more than 20 seconds, reset it to Outside
 # This helps to ensure that Home Assistant gets nice updates each time they look in.
@@ -365,6 +366,7 @@ async def clear_lookedin_state(app):
                 log.warning("MQTT client not available, cannot update Home Assistant")
         
         await asyncio.sleep(check_interval)
+
 
 async def queue_mqtt(client, app):
     log.info("Client: Start")

--- a/pethublocal/frontend.py
+++ b/pethublocal/frontend.py
@@ -342,7 +342,7 @@ async def parse_message(client, app, messages):
     async for message in messages:
         if message.topic.startswith(PH_HUB_T) or message.topic.startswith(PH_HA_T):
             parsed_result = parse_mqtt_message(app['pethubconfig'], message.topic, message.payload.decode())
-            await sio.emit('web_message', data=parsed_result, broadcast=True, include_self=False)
+            await sio.emit('web_message', data=parsed_result)
             if 'HubMessage' in parsed_result:
                 log.debug('ToHub: Parsed Message %s', parsed_result['HubMessage'])
                 for hub_message in parsed_result['HubMessage']:
@@ -357,7 +357,6 @@ async def parse_message(client, app, messages):
 
         if message.topic.startswith('pethub/in'):
             print('emit message', message.payload.decode())
-            # await sio.emit('web_state', data=message.payload.decode(), broadcast=True, include_self=False)
 
 
 async def cancel_tasks(tasks):

--- a/pethublocal/frontend.py
+++ b/pethublocal/frontend.py
@@ -39,10 +39,10 @@ from .consts import (
     MQTTSLEEP,
     FIRMWAREVERSION
 )
+from importlib.resources import files
 
 import logging
 from logging.handlers import TimedRotatingFileHandler
-import pkg_resources
 logging.basicConfig(
     level=LOGLEVEL,
 )
@@ -118,9 +118,9 @@ async def https_app(pet_hub_config):
     cert = config['Web']['Cert']
     cert_key = config['Web']['CertKey']
     if not os.path.isfile(cert):
-        package_dir = pkg_resources.resource_filename('pethublocal', "static")
-        cert = package_dir + '/' + cert
-        cert_key = package_dir + '/' + cert_key
+        package_dir = files("pethublocal") / "static"
+        cert = str(package_dir / cert)
+        cert_key = str(package_dir / cert_key)
     ssl_context.load_cert_chain(cert, cert_key)
     app_s = web.Application()
     app_s['pethubconfig'] = pet_hub_config
@@ -417,7 +417,7 @@ def serve_pet_hub():
     app.router.add_post('/api/firmware', firmware)
     app.router.add_get('/pethubconfig', pethubconfig)
     app.router.add_route('*', '/', root_handler)
-    app.router.add_static('/', pkg_resources.resource_filename('pethublocal', "static"))
+    app.router.add_static('/', str(files("pethublocal") / "static"))
     app.on_startup.append(start_tasks)
     log.info("Starting HTTP Server")
     web.run_app(

--- a/pethublocal/frontend.py
+++ b/pethublocal/frontend.py
@@ -203,6 +203,7 @@ async def start_tasks(app):
     loop.create_task(hub_watchdog(app))
     loop.create_task(clear_lookedin_state(app))
 
+
 async def mqtt_start(app):
     reconnect_interval = 3  # [seconds]
     while True:

--- a/pethublocal/frontend.py
+++ b/pethublocal/frontend.py
@@ -327,7 +327,7 @@ async def hub_watchdog(app):
 # This helps to ensure that Home Assistant gets nice updates each time they look in.
 async def clear_lookedin_state(app):
     check_interval = 10  # [seconds]
-    state_expiration = 20 # [seconds]
+    state_expiration = 30 # [seconds]
     client = app.get('mqtt_client')
 
     while True:

--- a/pethublocal/functions.py
+++ b/pethublocal/functions.py
@@ -361,7 +361,7 @@ def config_load(setup=False, force=False):
                         start = Box.from_json(filename=config.Config.Cloud.StartJSON)
                 if 'StartJSON' not in config.Config.Cloud:
                     start.merge_update(download_start(config))
-                if len(start) > 1:
+                if len(start.data) > 5:
                     log.info('Start downloaded, saving base config %s', start.to_json())
                     continue_setup = input('Continue with setup using this start file? If you need to make changes to it before applying to the config, now is the time to do so. Press Y to continue or N to make changes')
                     if len(continue_setup) > 0 and continue_setup[0].upper() == 'N':

--- a/pethublocal/functions.py
+++ b/pethublocal/functions.py
@@ -783,7 +783,7 @@ def ha_init_entities(pethubconfig):
                 for key in lockstate:
                     devidkey = devid + '_' + key.lower()
                     config_message = Box({
-                        'name': attrs.Name + ' ' + key,
+                        'name': attrs.Name + ' Mode ' + key,
                         'ic': icon,
                         'uniq_id': devidkey,
                         'stat_t': PH_HA_T + devid + '/state',
@@ -815,10 +815,12 @@ def ha_init_entities(pethubconfig):
                     {"key": PetDoorCustomMode.DoubleChip3.name, "custIcon": "mdi:chip"},
                     {"key": PetDoorCustomMode.ProximityTest.name, "custIcon": "mdi:radio-tower"}
                 ]
-                for key, custIcon in customModes:
+                for mode in customModes:
+                    key = mode["key"]
+                    custIcon = mode["custIcon"]
                     devidkey = devid + '_' + key.lower()
                     config_message = Box({
-                        'name': attrs.Name + ' ' + key,
+                        'name': attrs.Name + ' Cstm Mode ' + key,
                         'ic': custIcon,
                         'uniq_id': devidkey,
                         'stat_t': PH_HA_T + devid + '/state',

--- a/pethublocal/functions.py
+++ b/pethublocal/functions.py
@@ -2,6 +2,7 @@
  Pet Hub Shared functions
  Copyright (c) 2022, Peter Lambrechtsen (peter@crypt.nz)
 """
+import ast
 from datetime import datetime, timedelta
 import json
 import os
@@ -1002,7 +1003,14 @@ def ha_update_state(pethubconfig, *devicepet):
                         'Curfew': 'ON' if curfew else 'OFF',
                         'Curfews': str(attrs.Curfews)
                     })
-                    if 'Custom_Modes' in attrs:  # Add custom mode
+                    if 'Custom_Modes' in attrs:
+                        try:
+                            custom_modes_str = attrs.Custom_Modes
+                            custom_modes = ast.literal_eval(custom_modes_str)
+                            log.debug(f"Parsed Custom Modes: {custom_modes}")
+                        except Exception as e:
+                            log.error(f"Error parsing Custom_Modes: {e}")
+                            custom_modes = []
                         state_message.merge_update({"CustomMode": attrs.Custom_Modes})
                     mqtt_messages.merge_update({PH_HA_T + devid + '/state': state_message.to_json()})
 

--- a/pethublocal/functions.py
+++ b/pethublocal/functions.py
@@ -552,7 +552,7 @@ def start_to_pethubconfig(config, data):
                 if key in control_fields:
                     device_result.merge_update({key.title(): val})
             if 'version' in device:
-                device_result.merge_update({'Main_Version': str(base64.b64decode(device.version).decode('utf-8'))})
+                device_result.merge_update({'Main_Version': str(device.version)})
 
             # Pet Door or Cat Flap
             if device.product_id in [3, 6]:

--- a/pethublocal/functions.py
+++ b/pethublocal/functions.py
@@ -363,6 +363,10 @@ def config_load(setup=False, force=False):
                     start.merge_update(download_start(config))
                 if len(start) > 1:
                     log.info('Start downloaded, saving base config %s', start.to_json())
+                    continue_setup = input('Continue with setup using this start file? If you need to make changes to it before applying to the config, now is the time to do so. Press Y to continue or N to make changes')
+                    if len(continue_setup) > 0 and continue_setup[0].upper() == 'N':
+                        log.info('Exiting setup, please edit the start file %s and re-run', config.Config.Cloud.StartJSON)
+                        sys.exit(0)
                     config.merge_update(start_to_pethubconfig(config, start))
                     config_save(config)
                     log.info('Start parsed and saved to config')
@@ -555,9 +559,10 @@ def start_to_pethubconfig(config, data):
         log.error("No devices found in payload from SurePetCare. Make sure you have a hub and accessory registered to your account. \n"
                   "You may not wish to connect your V1 hub to the internet for this, it may result in a firmware upgrade that breaks this project. \n"
                   "My only suggestion is to use a V2 hub and temporarily pair it with your accessories. That will generate the correct config in the cloud. \n"
-                  "After that, manually update the config in the start.json file to replace the references to the V2 hub with the V1 hub. \n"
-                  "In particular, the serial number and MAC address of the V1 hub. Though there may be other differences, go through it line by line. \n"
-                  "Come back here and run the PetHubLocal setup again to generate the config file from the updated start.json file.")
+                  "After that, come back here and start the cloud set up again. Select to download a new start file. When given the option, exit the set up. "
+                  "Then, manually update the start.json file to replace the references to the V2 hub with the V1 hub. Essentially pretending this was what was pulled from the cloud. \n"
+                  "Then, come back once more and run the PetHubLocal setup. This time, say to NOT download a new start file and the installer will use the one you just updated. \n"
+                  "In particular, the serial number and MAC address of the V1 hub will need updating in the start file. There may be other differences, go through it line by line.")
         sys.exit(1)
 
     # Parent Serial Number, assumption this is always the first device serial number.

--- a/pethublocal/functions.py
+++ b/pethublocal/functions.py
@@ -998,8 +998,8 @@ def ha_update_state(pethubconfig, *devicepet):
                             LockState(attrs.Locking_Mode).name.title()
                         ),
                         'Battery': str(attrs.Battery),
-                        'Keep In': 'ON' if attrs.Locking_Mode in [LockState.KEEPIN, LockState.LOCKED] else 'OFF',
-                        'Keep Out': 'ON' if attrs.Locking_Mode in [LockState.KEEPOUT, LockState.LOCKED] else 'OFF',
+                        'KeepIn': 'ON' if attrs.Locking_Mode in [LockState.KEEPIN, LockState.LOCKED] else 'OFF',
+                        'KeepOut': 'ON' if attrs.Locking_Mode in [LockState.KEEPOUT, LockState.LOCKED] else 'OFF',
                         'Curfew': 'ON' if curfew else 'OFF',
                         'Curfews': str(attrs.Curfews)
                     })

--- a/pethublocal/functions.py
+++ b/pethublocal/functions.py
@@ -797,6 +797,41 @@ def ha_init_entities(pethubconfig):
                     mqtt_messages.merge_update({
                         HA_SWITCH + devidkey + '/config': config_message.to_json()
                     })
+                customModes = [
+                    {"key": PetDoorCustomMode.Disabled.name, "custIcon": "mdi:cancel"},
+                    {"key": PetDoorCustomMode.NonSelective.name, "custIcon": "mdi:door-sliding-open"},
+                    {"key": PetDoorCustomMode.Rechargeables.name, "custIcon": "mdi:battery"},
+                    {"key": PetDoorCustomMode.ThreeSeconds.name, "custIcon": "mdi:timer-3"},
+                    {"key": PetDoorCustomMode.TenSeconds.name, "custIcon": "mdi:timer-10"},
+                    {"key": PetDoorCustomMode.Intruder.name, "custIcon": "mdi:shark-off"},
+                    {"key": PetDoorCustomMode.OppositeCurfew.name, "custIcon": "mdi:clock-end"},
+                    {"key": PetDoorCustomMode.LockedCurfew.name, "custIcon": "mdi:lock-clock"},
+                    {"key": PetDoorCustomMode.MetalMode1.name, "custIcon": "mdi:shield"},
+                    {"key": PetDoorCustomMode.MetalMode2.name, "custIcon": "mdi:shield-outline"},
+                    {"key": PetDoorCustomMode.ExtendedRange.name, "custIcon": "mdi:signal"},
+                    {"key": PetDoorCustomMode.ExtendedIntruder.name, "custIcon": "mdi:shark-off"},
+                    {"key": PetDoorCustomMode.DoubleChip1.name, "custIcon": "mdi:chip"},
+                    {"key": PetDoorCustomMode.DoubleChip2.name, "custIcon": "mdi:chip"},
+                    {"key": PetDoorCustomMode.DoubleChip3.name, "custIcon": "mdi:chip"},
+                    {"key": PetDoorCustomMode.ProximityTest.name, "custIcon": "mdi:radio-tower"}
+                ]
+                for key, custIcon in customModes:
+                    devidkey = devid + '_' + key.lower()
+                    config_message = Box({
+                        'name': attrs.Name + ' ' + key,
+                        'ic': custIcon,
+                        'uniq_id': devidkey,
+                        'stat_t': PH_HA_T + devid + '/state',
+                        'val_tpl': '{{value_json.Custom_Mode}}',
+                        'json_attr_t': PH_HA_T + devid + '/state',
+                        'cmd_t': PH_HA_T + devid + '/custom_mode',
+                        'avty_t': PH_HA_T + devid + '/state',
+                        'avty_tpl': '{{value_json.Availability}}',
+                        'device': device_config
+                    })
+                    mqtt_messages.merge_update({
+                        HA_SWITCH + devidkey + '/config': config_message.to_json()
+                    })
             elif attrs.Product_Id == 4:
                 icon = 'mdi:bowl'
             elif attrs.Product_Id == 8:

--- a/pethublocal/functions.py
+++ b/pethublocal/functions.py
@@ -361,7 +361,7 @@ def config_load(setup=False, force=False):
                         start = Box.from_json(filename=config.Config.Cloud.StartJSON)
                 if 'StartJSON' not in config.Config.Cloud:
                     start.merge_update(download_start(config))
-                if len(start) > 5:
+                if len(start) > 1:
                     # log.info('Start downloaded, saving base config %s', start.to_json())
                     config.merge_update(start_to_pethubconfig(config, start))
                     config_save(config)

--- a/pethublocal/functions.py
+++ b/pethublocal/functions.py
@@ -988,8 +988,8 @@ def ha_update_state(pethubconfig, *devicepet):
                         'Availability': attrs.State.lower() if 'State' in attrs else 'offline',
                         'State': LockState(attrs.Locking_Mode).name.title(),
                         'Battery': str(attrs.Battery),
-                        'KeepIn': 'ON' if attrs.Locking_Mode in [1, 3] else 'OFF',
-                        'KeepOut': 'ON' if attrs.Locking_Mode in [2, 3] else 'OFF',
+                        'KeepIn': 'ON' if attrs.Locking_Mode in [LockState.KEEPIN, LockState.LOCKED] else 'OFF',
+                        'KeepOut': 'ON' if attrs.Locking_Mode in [LockState.KEEPOUT, LockState.LOCKED] else 'OFF',
                         'Curfew': 'ON' if curfew else 'OFF',
                         'Curfews': str(attrs.Curfews)
                     })

--- a/pethublocal/functions.py
+++ b/pethublocal/functions.py
@@ -15,7 +15,6 @@ import dns.resolver
 import sys
 import codecs
 import urllib3
-import pkg_resources
 
 from pygments import highlight
 from pygments.lexers import JsonLexer
@@ -26,6 +25,7 @@ from .message import parse_hub
 from .consts import *
 from . import log
 from .enums import *
+from importlib.resources import files
 
 # Disable annoying urllib HTTPS Warnings
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -1262,7 +1262,7 @@ def build_firmware(xor_key, serial_number):
     firmware = f'{serial_number}-{FIRMWAREVERSION}-00.bin'
     if not os.path.isfile(firmware):
         log.info('Firmware: Building version %s firmware', str(FIRMWAREVERSION))
-        package_dir = pkg_resources.resource_filename('pethublocal', "firmware")
+        package_dir = files("pethublocal") / "firmware"
         # Find the number of records / pages based on FIRMWAREVERSION
         with open(f'{package_dir}/Firmware-{FIRMWAREVERSION}-00.bin', 'rb') as f:
             headersplit = f.read(36).decode("utf-8").split()

--- a/pethublocal/functions.py
+++ b/pethublocal/functions.py
@@ -1109,7 +1109,7 @@ def parse_mqtt_message(pethubconfig, mqtt_topic, mqtt_message):
 
         # Pet Door or Cat Flap
         if (pid in [3, 6] and op in ['KeepIn', 'KeepOut']) or (pid == 3 and op == 'Curfew'):
-            if pid == 3 and op == 'Curfew':
+            if pid == 3 and op == 'Curfew' and mqtt_message == "ON":
                 nlm = 4
                 # Set Locking Mode
                 result.append(generatemessage(pethubconfig, hub, pid, 'CURFEWS', mac=mac,

--- a/pethublocal/message.py
+++ b/pethublocal/message.py
@@ -605,15 +605,19 @@ def parse_door_frame(pethubrecord, hub, device_item, offset, length):
     if offset in range(91, 309):  # Provisioned tags
         log.debug("PETDOOR: Register 91-309 - Provisioned Tags %s", str(message_range))
         operation.append("Tag")
-        frame_response.TagOffset = str(round((int(offset) - 84) / 7))  # Calculate the tag offset number
-        tag = door_hex_to_tag(registers[offset:offset+7])                  # Calculate tag Number
+        frame_response.TagOffset = str(round((int(offset) - 84) / 7) -1)  # Calculate the tag offset number (0 indexed. This wasn't originally the case, but it matches what's on line 634)
+        tag = door_hex_to_tag(registers[offset:offset+7])                 # Calculate tag Number
         frame_response.Tag = [tag]
         if tag != 'Empty':
+            log.info("Found tag in door message with value of %s at offset %s", tag, frame_response.TagOffset)
             if frame_response.TagOffset in pethubrecord['Tags']:
+                log.info("Matches existing offset")
                 if not pethubrecord['Tags'][frame_response.TagOffset]['Tag'] == tag:
+                    log.info("Updating tag %s at offset %s", tag, frame_response.TagOffset)
                     pethubrecord['Tags'][frame_response.TagOffset] = {"Tag": tag}
                     update_state = True
             else:
+                log.info("Adding new tag %s at offset %s", tag, frame_response.TagOffset)
                 pethubrecord['Tags'][frame_response.TagOffset] = {"Tag": tag}
                 update_state = True
                 New_Tag = True

--- a/sample-files/sample-pethubconfig.json
+++ b/sample-files/sample-pethubconfig.json
@@ -1,0 +1,111 @@
+{
+    "Config": {
+        "Deployment": "Cloud",
+        "Timezone": "Local",
+        "Last_HA_Init": 1753769954,
+        "Get_State": true,
+        "Last_Updated": "2025-07-30 06:43:47",
+        "Cloud": {
+            "LoggedIn": true,
+            "Username": "yourEmail@gmail.com",
+            "Password": "yourPetHubPassword",
+            "device_id": "", // Appears to get populated when you sign into the cloud using the pethublocal setup command.
+            "Token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkZha2UgVXNlciIsImlhdCI6MTcyMjI5NzYwMCwiZXhwIjoxNzIyMzAxMjAwfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+            "StartJSON": "start-20250729-031958.json"
+        },
+        "Web": {
+            "Host": "0.0.0.0",
+            "HTTPPort": 80,
+            "HTTPSPort": 443,
+            "Cert": "hub.pem",
+            "CertKey": "hub.key"
+        },
+        "MQTT": {
+            "Host": "192.168.1.100", // IP address of your MQTT Broker, this might be 127.0.0.1 if you are running the broker on the same machine as PetHubLocal.
+            "ClientUsername": "pethublocal",// If your MQTT broker requires a username and password, otherwise delete these.
+            "ClientPassword": "pethublocal"
+        },
+        "Firmware": {
+            "Cache": true,
+            "Force_Download": false
+        }
+    },
+    "Devices": {
+        "H002-0077777": { // Update this with the number on the underside of your hub
+            "Hub": {
+                "Name": "Main",
+                "Product_Id": 1,
+                "Serial_Number": "H002-0077777", // Update this with the number on the underside of your hub
+                "Mac_Address": "0000A47B3C19F2DE", // This is the MAC address of your hub. Don't get confused, it's the Ethernet MAC address on the underside, not the MiWi one for the radio that talks to the cat flap.
+                "Updated_At": "2025-07-29T03:08:28+00:00",
+                "Index": "Hub",
+                "Led_Mode": 1,
+                "Pairing_Mode": 0,
+                "State": "Online",
+                "Device": {
+                    "Hardware": "3",
+                    "Firmware": "2.43"
+                },
+                "Uptime": "1260",
+                "Main_Version": "58",
+                "UUID": "A random UUID (find an online generator)",
+                "Client_Cert": "", // I'm sorry, for me this was updated after I connected my V1 hub up to PetHubLocal. Seems to be hub specific. If you have a V1 hub on the older firmware, you can probably run through the setup and have it populate it.
+                "Reconnects": "1"
+            },
+            "": { // This is the MAC address for the pet door (unlike the HUB, this is the radio MAC). I was able to get this by sniffing the traffic between a new hub and the pet door using Wireshark and a CC2531. Saved me hooking older hub up to internet and risking a firmware update.
+                "Name": "Main Door",
+                "Product_Id": 3,
+                "Index": 0,
+                "Mac_Address": "", // Same MAC as above.
+                "Updated_At": "2025-07-29T03:17:59+00:00",
+                "Last_Device_Update": 1753769955,
+                "Fast_Polling": true,
+                "Curfew_Enabled": false,
+                "Curfews": "12:01-12:02",
+                "Locking_Mode": 0,
+                "State": "Online",
+                "Learn_Mode": false,
+                "Battery": "6.2025",
+                "BatteryADC": "182",
+                "Lcd": {
+                    "Hardware": "1.0",
+                    "Firmware": "1.0"
+                },
+                "Rf": {
+                    "Hardware": "4.0",
+                    "Firmware": "0.21"
+                },
+                "Device": {
+                    "Hardware": "1.2",
+                    "Firmware": "1.1"
+                },
+                "Device_Rssi": -55,
+                "Hub_Rssi": -70,
+                "Tags": {
+                    "0": {
+                        "Tag": "999.000099999999", // Number of the chip on the first pet registered on the door. I found it in their little medical booklet.
+                        "Profile": 2
+                    },
+                    "1": {
+                        "Tag": "999.000099999998", // Same as above, but for the second pet.
+                        "Profile": 2
+                    }
+                },
+                "Main_Version": "9",
+                "Last_Heard": "436535652",
+                "Locked_Out_State": "Normal"
+            }
+        }
+    },
+    "Pets": {
+        "999.000099999999": {
+            "Name": "Cat1",
+            "Species": 1
+            }
+        },
+        "999.000099999998": {
+            "Name": "Cat2",
+            "Species": 1
+        }
+    }
+}


### PR DESCRIPTION
I know this project is kinda dead in the water until we can figure out a hub replacement.

Until then, I've been able to set this up using a V1 hub running firmware version 2.43.

Along the way I found a few broken things, some were just packages that were out of date, others were what I believe to be missing functionality. While I was at it, I also added a couple of feature enhancements.

Adding here in the hopes that it benefits other people who are still running this with their 2.43 hubs.

I'll be clear, I don't know the code very well, and the only connected product I own is the Pet Door. So the changes I've made possibly have ramifications elsewhere in the code (though I've yet to see any and I've been running this branch myself for a little while) or cause issues with other connected devices.

Also, due to not knowing the codebase very well, the quality of my code is probably hot garbage. Sorry, a lot of this is awkward hacky patches rather than a full refactor. Didn't seem worth it as the general consensus is this project is dead.

* Fixed a known issue with an out of date SIO package which had a breaking change.
* Fixed the setup flow where it reads from a previous `start` file (was looking for more children than that layer had)
* Fixed a known issue with the "version" field in the `pethubconfig.json` being an int and failing the base64 decode.
* Slight updates to the way the firmware update happens, new messages that warn about incompatible firmware.
* Update to the MQTT setup, allows user to enter the Username and Password for the MQTT broker (if applicable).
* Added a sample pethubconfig.json file. I was able to put mine together using my cloud config which I had thanks to a V2 hub (didn't want to plug V1 hub in and risk update). Hopefully this might help someone get started if they only have a V1 hub and need an idea of what the config file looks like.
* Refactored out some deprecated packages which were causing issues on startup in some case.
* Added the option to can out of set up early in order to make changes to the `start.json` manually (like I had to when using a start file from my V2 hub and modifying it for my V1) and then picking up where you left off.
* Fix for the curfew toggle in Home Assistant not switching off. For some reason to disable Curfew you had to toggle on another mode which would turn both off. It was weird. Now all switches turn on and off as expected.
* Added a reset timer that reverts the state of a pet that has looked in through the cat door. This means you can see seperate instances of your pet looking in, leaving, coming back, looking in again etc. Rather than just a single "LookedIn" state from when they first looked in to when they eventually came inside.

More updates will no doubt come as I continue to tinker with this for my own usages, but I wanted to put this branch out there in case these changes appealed to anyone.